### PR TITLE
:sparkles:Text: Add Cosine Similarity and Distance calculation algorithms

### DIFF
--- a/Text/Similarity/Cosine/CosineDistance.cs
+++ b/Text/Similarity/Cosine/CosineDistance.cs
@@ -1,0 +1,25 @@
+﻿namespace Text.Similarity.Cosine;
+
+/// <summary>
+/// Measures the cosine distance between two strings.
+/// <para>
+/// It utilizes the <see cref="CosineSimilarity"/> to compute the distance. Strings are converted into vectors through
+/// a simple tokenizer that works with a regular expression to split words in a sentence.
+/// </para>
+/// </summary>
+public class CosineDistance : IEditDistance<double>
+{
+    private readonly CosineSimilarity _cosineSimilarity = new CosineSimilarity();
+
+    /// <summary>
+    /// Compares two strings.
+    /// </summary>
+    /// <param name="left">The first string.</param>
+    /// <param name="right">The second string.</param>
+    /// <returns>The similarity score between the two strings.</returns>
+    public double Calculate(string left, string right)
+    {
+        var similarity = _cosineSimilarity.Calculate(left, right);
+        return 1.0 - similarity;
+    }
+}

--- a/Text/Similarity/Cosine/CosineSimilarity.cs
+++ b/Text/Similarity/Cosine/CosineSimilarity.cs
@@ -1,0 +1,71 @@
+﻿using Text.Similarity.Tokenizers;
+
+namespace Text.Similarity.Cosine;
+
+/// <summary>
+/// Measures the Cosine similarity of two vectors of an inner product space and compares the angle between them.
+/// </summary>
+public class CosineSimilarity : ISimilarityScore<double>
+{
+    private readonly ITokenizer<string> _tokenizer = new WordTokenizer();
+
+    /// <summary>
+    /// Calculates the cosine similarity for two given strings.
+    /// </summary>
+    /// <param name="left">The first string.</param>
+    /// <param name="right">The second string.</param>
+    /// <returns>The cosine similarity between the two strings.</returns>
+    public double Calculate(string left, string right)
+    {
+        var leftTokens = _tokenizer.Tokenize(left);
+        var rightTokens = _tokenizer.Tokenize(right);
+
+        var leftVector = Counter.Of(leftTokens);
+        var rightVector = Counter.Of(rightTokens);
+
+        return GetCosineSimilarity(leftVector, rightVector);
+    }
+    
+    private double GetCosineSimilarity(Dictionary<string, int> leftVector, Dictionary<string, int> rightVector)
+    {
+        if (leftVector == null || rightVector == null)
+            throw new ArgumentNullException(leftVector == null ? nameof(leftVector) : nameof(rightVector),
+                "Vectors cannot be null");
+
+        var intersection = GetIntersection(leftVector, rightVector);
+        var dotProduct = GetDotProduct(leftVector, rightVector, intersection);
+
+        var d1 = leftVector.Values.Sum(value => Math.Pow(value, 2));
+        var d2 = rightVector.Values.Sum(value => Math.Pow(value, 2));
+
+        double cosineSimilarity;
+
+        if (d1 <= 0.0 || d2 <= 0.0)
+            cosineSimilarity = 0.0;
+        else
+            cosineSimilarity = dotProduct / (Math.Sqrt(d1) * Math.Sqrt(d2));
+
+        return cosineSimilarity;
+    }
+
+    private static double GetDotProduct(
+        IReadOnlyDictionary<string, int> leftVector,
+        IReadOnlyDictionary<string, int> rightVector,
+        IEnumerable<string> intersection)
+    {
+        return intersection.Aggregate(0L, (current, key) => current + leftVector[key] * rightVector[key]);
+    }
+
+    private static IEnumerable<string> GetIntersection(
+        Dictionary<string, int> leftVector,
+        Dictionary<string, int> rightVector)
+    {
+        var intersection = new HashSet<string>();
+        intersection.UnionWith(leftVector.Keys);
+        intersection.IntersectWith(rightVector.Keys);
+
+        return intersection;
+    }
+
+    
+}

--- a/TextTests/Similarity/Cosine/CosineDistanceTests.cs
+++ b/TextTests/Similarity/Cosine/CosineDistanceTests.cs
@@ -1,0 +1,6 @@
+﻿namespace TextTests.Similarity.Cosine;
+
+public class CosineDistanceTests
+{
+    
+}

--- a/TextTests/Similarity/Cosine/CosineSimilarityTests.cs
+++ b/TextTests/Similarity/Cosine/CosineSimilarityTests.cs
@@ -1,0 +1,28 @@
+﻿using Text.Similarity.Cosine;
+
+namespace TextTests.Similarity.Cosine;
+
+[TestFixture]
+public class CosineSimilarityTests
+{
+    [Test]
+    public void CosineSimilarityReturnsDoubleWhereByteValueIsZero()
+    {
+        var cosineSimilarity = new CosineSimilarity();
+
+        var result = cosineSimilarity.Calculate("", "");
+
+        Assert.That(result, Is.EqualTo(0.0).Within(0.01));
+    }
+
+    [Test]
+    public void CosineSimilarityThrowsArgumentNullExceptionForNullDictionary()
+    {
+        var cosineSimilarity = new CosineSimilarity();
+        
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            cosineSimilarity.Calculate("string", null);
+        });
+    }
+}

--- a/TextTests/TextTests.csproj
+++ b/TextTests/TextTests.csproj
@@ -16,4 +16,8 @@
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Text\Text.csproj" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Add the implementation of the Cosine Similarity and Distance algorithms.

Cosine distance is a measure of similarity between two strings. It is calculated as the cosine of the angle between the two strings in a vector space, where each string is represented as a vector of term frequencies. The cosine distance is defined as 1 minus the cosine similarity, so a smaller cosine distance indicates a higher degree of similarity between the two strings.

Cosine distance is often used in natural language processing and information retrieval tasks to measure the similarity between documents or text strings. It is particularly useful for comparing strings that have different lengths, as it takes into account the relative frequencies of the terms rather than their absolute counts.

To calculate the cosine distance and similarity the algorithm first converts the strings into vectors of term frequencies. This involves tokenizing the strings into individual words and then counting the number of occurrences of each term in each string. The resulting vectors can then be used to calculate the cosine distance using the following formula:

cosine distance = 1 - (A * B) / (||A|| * ||B||)

Where A and B are the term frequency vectors for the two strings, and ||A|| and ||B|| are the magnitudes of the vectors. The cosine distance will always be a value between 0 and 1, with a value of 0 indicating that the two strings are identical and a value of 1 indicating that the two strings are completely dissimilar.