### PR TITLE
:sparkles: Text: Add Fuzzy Score Algorithm

### DIFF
--- a/Text/Similarity/Fuzzy/FuzzyScore.cs
+++ b/Text/Similarity/Fuzzy/FuzzyScore.cs
@@ -1,0 +1,61 @@
+﻿using System.Globalization;
+
+namespace Text.Similarity.Fuzzy;
+
+public class FuzzyScore
+{
+    private readonly CultureInfo info;
+
+    public FuzzyScore(CultureInfo info)
+    {
+        this.info = info ?? throw new ArgumentNullException(nameof(info));
+    }
+
+    public int CalculateFuzzyScore(string term, string query)
+    {
+        if (term == null || query == null)
+            throw new ArgumentNullException(term == null ? nameof(term) : nameof(query)
+                , "Strings must not be null");
+
+        var lowerCaseTerm = term.ToLower(info);
+        var lowerCaseQuery = query.ToLower(info);
+
+        // the resulting score
+        var score = 0;
+
+        // the position in the term which will be scanned next for potential
+        // query character matches
+        var termIndex = 0;
+
+        // index of the previously matched character in the term
+        var previousMatchingCharacterIndex = int.MinValue;
+
+        foreach (var queryChar in lowerCaseQuery)
+        {
+            for (; termIndex < lowerCaseTerm.Length; termIndex++)
+            {
+                var termChar = lowerCaseTerm[termIndex];
+
+                if (queryChar == termChar)
+                {
+                    // simple character matches result in one point
+                    score++;
+
+                    // subsequent character matches further improve
+                    // the score.
+                    if (previousMatchingCharacterIndex + 1 == termIndex)
+                        score += 2;
+
+                    previousMatchingCharacterIndex = termIndex;
+
+                    // we can leave the nested loop. Every character in the
+                    // query can match at most one character in the term.
+                    break;
+                }
+            }
+        }
+
+        return score;
+    }
+
+}

--- a/TextTests/Similarity/Fuzzy/FuzzyScoreTests.cs
+++ b/TextTests/Similarity/Fuzzy/FuzzyScoreTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Globalization;
+using Text.Similarity.Fuzzy;
+
+namespace TextTests.Similarity.Fuzzy;
+
+[TestFixture]
+public class FuzzyScoreTests
+{
+    private static readonly FuzzyScore EnglishScore = new FuzzyScore(CultureInfo.GetCultureInfo("en-US"));
+    
+    [TestCase("", "", 0)]
+    [TestCase("Workshop", "b", 0)]
+    [TestCase("Room", "o", 1)]
+    [TestCase("Workshop", "w", 1)]
+    [TestCase("Workshop", "ws", 2)]
+    [TestCase("Workshop", "wo", 4)]
+    public void TestGetFuzzyScore(string term, string query, int expectedScore)
+    {
+        Assert.That(EnglishScore.CalculateFuzzyScore(term, query), Is.EqualTo(expectedScore));
+    }
+    
+    [Test]
+    public void FuzzyScore_NullNullLocale_ThrowsArgumentException()
+    {
+        Assert.That(() => EnglishScore.CalculateFuzzyScore(null, null), Throws.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void FuzzyScore_NullStringLocale_ThrowsArgumentException()
+    {
+        Assert.That(() => EnglishScore.CalculateFuzzyScore(null, "not null"), Throws.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void FuzzyScore_StringNullLocale_ThrowsArgumentException()
+    {
+        Assert.That(() => EnglishScore.CalculateFuzzyScore("not null", null), Throws.TypeOf<ArgumentNullException>());
+    }
+    
+    [Test]
+    public void Constructor_NullLocale_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FuzzyScore(null));
+    }
+}


### PR DESCRIPTION
 A fuzzy score is a measure of how similar two strings are. It is calculated using a set of rules or algorithms that take into account various factors such as the length of the strings, the number of common characters, and the position of the characters in the strings. A fuzzy score is typically a value between 0 and 1, with a value of 0 indicating that the strings are completely dissimilar and a value of 1 indicating that the strings are identical.

For example, consider a user who is searching for the string "cat" in a database of animal names. If the database contains the strings "cat", "cats", "catnip", and "catacombs", a fuzzy scoring algorithm might be used to calculate the similarity between the search query and each of the strings in the database. The resulting fuzzy scores could be used to rank the strings in order of similarity, with the string "cat" receiving the highest score and the string "catacombs" receiving the lowest score.

The algorithm calculates the fuzzy score between two strings, term and query. It converts both strings to lowercase and then iterates through each character in the query string. For each character in the query string, it scans the term string looking for a match and increments the score by 1 if a match is found. If the position of the matching character in the term string is immediately after the position of the previously matched character, the score is also incremented by 2. The method returns the final score as the fuzzy score between the two strings.