### PR TITLE
:sparkles: Text: Add Jaro-Winkler Distance and Similarity Calculation

### DIFF
--- a/Text/Similarity/JaroWinkler/JaroWinklerDistance.cs
+++ b/Text/Similarity/JaroWinkler/JaroWinklerDistance.cs
@@ -1,0 +1,25 @@
+﻿namespace Text.Similarity.JaroWinkler;
+
+/// <summary>
+/// Measures the Jaro-Winkler distance of two strings. It is the complementary of Jaro-Winkler distance.
+/// </summary>
+public class JaroWinklerDistance : IEditDistance<double>
+{
+    private readonly JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
+
+    /// <summary>
+    /// Computes the Jaro-Winkler distance between two strings.
+    /// </summary>
+    /// <param name="left">The first string, must not be null.</param>
+    /// <param name="right">The second string, must not be null.</param>
+    /// <returns>The Jaro Winkler similarity.</returns>
+    /// <exception cref="ArgumentNullException">If any of the two strings is null.</exception>
+    public double Calculate(string left, string right)
+    {
+        if (left == null || right == null)
+            throw new ArgumentNullException(left == null ? nameof(left) : nameof(right), 
+                "Strings must not be null");
+
+        return 1 - similarity.Calculate(left, right);
+    }
+}

--- a/Text/Similarity/JaroWinkler/JaroWinklerSimilarity.cs
+++ b/Text/Similarity/JaroWinkler/JaroWinklerSimilarity.cs
@@ -1,0 +1,117 @@
+﻿namespace Text.Similarity.JaroWinkler;
+
+/// <summary>
+/// A similarity algorithm indicating the percentage of matched characters between two strings.
+/// </summary>
+public class JaroWinklerSimilarity : ISimilarityScore<double>
+{
+    /// <summary>
+    /// Calculate the Jaro-Winkler string matches, half transpositions, prefix array.
+    /// </summary>
+    /// <param name="first">The first string</param>
+    /// <param name="second">The second string</param>
+    /// <returns>Matches, transpositions, and prefix</returns>
+    protected static int[] Matches(string first, string second)
+    {
+        string max = first.Length > second.Length ? first : second;
+        string min = first.Length > second.Length ? second : first;
+
+        var range = Math.Max(max.Length / 2 - 1, 0);
+
+        var matchIndices = new int[min.Length];
+        for (var i = 0; i < matchIndices.Length; i++)
+        {
+            matchIndices[i] = -1;
+        }
+
+        var matchFlags = new bool[max.Length];
+        var matches = 0;
+
+        for (var minIndex = 0; minIndex < min.Length; minIndex++)
+        {
+            var c1 = min[minIndex];
+            var xn = Math.Min(minIndex + range + 1, max.Length);
+
+            for (var xi = Math.Max(minIndex - range, 0); xi < xn; xi++)
+            {
+                if (!matchFlags[xi] && c1 == max[xi])
+                {
+                    matchIndices[minIndex] = xi;
+                    matchFlags[xi] = true;
+                    matches++;
+                    break;
+                }
+            }
+        }
+
+        var ms1 = new char[matches];
+        var ms2 = new char[matches];
+        var si = 0;
+
+        for (var i = 0; i < min.Length; i++)
+        {
+            if (matchIndices[i] != -1)
+            {
+                ms1[si] = min[i];
+                si++;
+            }
+        }
+
+        si = 0;
+        for (var i = 0; i < max.Length; i++)
+        {
+            if (matchFlags[i])
+            {
+                ms2[si] = max[i];
+                si++;
+            }
+        }
+
+        var halfTranspositions = 0;
+        for (var mi = 0; mi < ms1.Length; mi++)
+        {
+            if (ms1[mi] != ms2[mi])
+            {
+                halfTranspositions++;
+            }
+        }
+
+        var prefix = 0;
+        for (var mi = 0; mi < Math.Min(4, min.Length); mi++)
+        {
+            if (first[mi] != second[mi])
+                break;
+
+            prefix++;
+        }
+
+        return new[] { matches, halfTranspositions, prefix };
+    }
+
+    /// <summary>
+    /// Computes the Jaro Winkler Similarity between two character sequences.
+    /// </summary>
+    /// <param name="left">The first string, must not be null.</param>
+    /// <param name="right">The second string, must not be null.</param>
+    /// <returns>The similarity</returns>
+    /// <exception cref="ArgumentException">If any of the strings is null.</exception>
+    public double Calculate(string left, string right)
+    {
+        const double defaultScalingFactor = 0.1;
+
+        if (left == null || right == null)
+            throw new ArgumentNullException(left == null ? nameof(left) : nameof(right), "Strings must not be null");
+
+        if (left.Equals(right))
+            return 1d;
+
+        var mpt = Matches(left, right);
+        double m = mpt[0];
+
+        if (m == 0)
+            return 0d;
+
+        var j = (m / left.Length + m / right.Length + (m - (double)mpt[1] / 2) / m) / 3;
+        return j < 0.7d ? j : j + defaultScalingFactor * mpt[2] * (1d - j);
+    }
+}

--- a/TextTests/Similarity/JaroWinkler/JaroWinklerDistanceTests.cs
+++ b/TextTests/Similarity/JaroWinkler/JaroWinklerDistanceTests.cs
@@ -1,0 +1,46 @@
+﻿using Text.Similarity.JaroWinkler;
+
+namespace TextTests.Similarity.JaroWinkler;
+
+[TestFixture]
+public class JaroWinklerDistanceTests
+{
+    private JaroWinklerDistance distance;
+
+    [SetUp]
+    public void Init()
+    {
+        distance = new JaroWinklerDistance();
+    }
+
+
+    [TestCase(null, null)]
+    [TestCase(null, "clear")]
+    [TestCase(" ", null)]
+    public void JaroWinklerDistance_WithNullStrings_ThrowsArgumentNullException(string left, string right)
+    {
+        Assert.Throws<ArgumentNullException>(() => { distance.Calculate(left, right); });
+    }
+
+    [TestCase("", "", 1 - 1d, 0.00001d)]
+    [TestCase("foo", "foo", 1 - 1d, 0.00001d)]
+    [TestCase("foo", "foo ", 1 - 0.94166d, 0.00001d)]
+    [TestCase("foo", "foo  ", 1 - 0.90666d, 0.00001d)]
+    [TestCase("foo", " foo ", 1 - 0.86666d, 0.00001d)]
+    [TestCase("foo", "  foo", 1 - 0.51111d, 0.00001d)]
+    [TestCase("frog", "fog", 1 - 0.92499d, 0.00001d)]
+    [TestCase("fly", "ant", 1 - 0.0d, 0.00000000000000000001d)]
+    [TestCase("elephant", "hippo", 1 - 0.44166d, 0.00001d)]
+    [TestCase("ABC Corporation", "ABC Corp", 1 - 0.90666d, 0.00001d)]
+    [TestCase("D N H Enterprises Inc", "D & H Enterprises, Inc.", 1 - 0.95251d, 0.00001d)]
+    [TestCase("My Gym Children's Fitness Center", "My Gym. Childrens Fitness", 1 - 0.942d, 0.00001d)]
+    [TestCase("PENNSYLVANIA", "PENNCISYLVNIA", 1 - 0.898018d, 0.00001d)]
+    [TestCase("/opt/software1", "/opt/software2", 1 - 0.971428d, 0.00001d)]
+    [TestCase("aaabcd", "aaacdb", 1 - 0.941666d, 0.00001d)]
+    [TestCase("John Horn", "John Hopkins", 1 - 0.911111d, 0.00001d)]
+    public void JaroWinklerDistance_WithValidStrings_ReturnsExpectedDistance(string left, 
+        string right, double expected, double threshold)
+    {
+        Assert.That(distance.Calculate(left, right), Is.EqualTo(expected).Within(threshold));
+    }
+}

--- a/TextTests/Similarity/JaroWinkler/JaroWinklerSimilarityTests.cs
+++ b/TextTests/Similarity/JaroWinkler/JaroWinklerSimilarityTests.cs
@@ -1,0 +1,45 @@
+﻿using Text.Similarity.JaroWinkler;
+
+namespace TextTests.Similarity.JaroWinkler;
+
+[TestFixture]
+public class JaroWinklerSimilarityTests
+{
+    private JaroWinklerSimilarity similarity;
+
+    [SetUp]
+    public void Init()
+    {
+        similarity = new JaroWinklerSimilarity();
+    }
+
+    [TestCase(null, null)]
+    [TestCase(null, "clear")]
+    [TestCase(" ", null)]
+    public void JaroWinklerSimilarity_WithNullStrings_ThrowsArgumentNullException(string left, string right)
+    {
+        Assert.Throws<ArgumentNullException>(() => { similarity.Calculate(left, right); });
+    }
+
+    [TestCase("", "", 1d, 0.00001d)]
+    [TestCase("foo", "foo", 1d, 0.00001d)]
+    [TestCase("foo", "foo ", 0.94166d, 0.00001d)]
+    [TestCase("foo", "foo  ", 0.90666d, 0.00001d)]
+    [TestCase("foo", " foo ", 0.86666d, 0.00001d)]
+    [TestCase("foo", "  foo", 0.51111d, 0.00001d)]
+    [TestCase("frog", "fog", 0.92499d, 0.00001d)]
+    [TestCase("fly", "ant", 0.0d, 0.00000000000000000001d)]
+    [TestCase("elephant", "hippo", 0.44166d, 0.00001d)]
+    [TestCase("ABC Corporation", "ABC Corp", 0.90666d, 0.00001d)]
+    [TestCase("D N H Enterprises Inc", "D & H Enterprises, Inc.", 0.95251d, 0.00001d)]
+    [TestCase("My Gym Children's Fitness Center", "My Gym. Childrens Fitness", 0.942d, 0.00001d)]
+    [TestCase("PENNSYLVANIA", "PENNCISYLVNIA", 0.898018d, 0.00001d)]
+    [TestCase("/opt/software1", "/opt/software2", 0.971428d, 0.00001d)]
+    [TestCase("aaabcd", "aaacdb", 0.941666d, 0.00001d)]
+    [TestCase("John Horn", "John Hopkins", 0.911111d, 0.00001d)]
+    public void JaroWinklerSimilarity_WithValidStrings_ReturnsExpectedSimilarity(string left,
+        string right, double expected, double threshold)
+    {
+        Assert.That(similarity.Calculate(left, right), Is.EqualTo(expected).Within(threshold));
+    }
+}


### PR DESCRIPTION
The Jaro-Winkler similarity is a measure of the similarity between two strings. It is based on the number of matching characters between the strings, with a higher score indicating a higher degree of similarity. The Jaro-Winkler distance is simply 1.0 minus the Jaro-Winkler similarity.

The Jaro-Winkler similarity can be thought of as a measure of how closely two strings match. For example, if you were comparing the strings "apple" and "apples", the Jaro-Winkler similarity would be high because there are a lot of matching characters between the two strings. On the other hand, if you were comparing the strings "apple" and "banana", the Jaro-Winkler similarity would be low because there are very few matching characters between the two strings.

The Jaro-Winkler distance works in a similar way, with a low distance indicating a high degree of similarity and a high distance indicating a low degree of similarity. For example, the Jaro-Winkler distance between "apple" and "apples" would be low, while the Jaro-Winkler distance between "apple" and "banana" would be high.

The solution is comprised of two functions.

The `Matches` function compares two strings and returns an array with three elements: the number of matching characters between the two strings, the number of half transpositions (when two characters are swapped in the other string), and the number of matching characters at the start of the strings (the prefix). It does this by setting max to the longer of the two strings and min to the shorter of the two strings, then initializing an array of matching indices and a boolean array of matched characters for the max string. It then iterates through each character in the min string and for each character, searches for a match in the max string within a certain range. If a match is found, the matching index and character are added to their respective arrays and the matches count is incremented. After all matching indices and characters have been collected, the number of half transpositions is calculated by comparing the matching characters. Finally, the number of matching prefix characters is counted.

The `Calculate` method calculates the Jaro-Winkler similarity between two strings left and right. If the strings are equal, it returns 1. Otherwise, it calls the `Matches` method with the two strings and calculates the Jaro similarity. If the Jaro similarity is less than 0.7, it returns the Jaro similarity. Otherwise, it returns the Jaro similarity plus a default scaling factor multiplied by the number of common prefix characters between the two strings (up to the first 4 characters) multiplied by the difference between 1 and the Jaro similarity.

The Jaro-Winkler distance is just the inverse of the similarity