### PR TITLE
:sparkles: Text: Add WordUtils.Abbreviate Function 

### DIFF
--- a/Text/WordUtils.cs
+++ b/Text/WordUtils.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+using System;
+
+namespace Text;
+
+public class WordUtils
+{
+    public static string Abbreviate(string str, int lower, int upper, string appendToEnd)
+    {
+        if (upper < -1)
+            throw new ArgumentOutOfRangeException(nameof(upper), "Upper value cannot be less than -1");
+        if (upper < lower && upper != -1)
+            throw new ArgumentOutOfRangeException(nameof(upper), "Upper value is less than lower value");
+
+        if (string.IsNullOrEmpty(str))
+            return str;
+    
+        // If the lower value is greater than the lenght of the string, set to the length of the string
+        if (lower > str.Length)
+            lower = str.Length;
+    
+        // If the upper value is -1 (meaning there is no limit) or is greater than the length of the string, set to the
+        // length of the string.
+        if (upper == -1 || upper > str.Length)
+            upper = str.Length;
+
+        var index = str.IndexOf(" ", lower, StringComparison.Ordinal);
+
+        if (index == -1)
+        {
+            // only if abbreviation has occurred do we append the appendToEnd value
+            return upper != str.Length ? str.Substring(0, upper) + appendToEnd : str;
+        }
+
+        return str.Substring(0, Math.Min(index, upper)) + appendToEnd;
+    }
+
+}

--- a/Text/WordUtils.cs
+++ b/Text/WordUtils.cs
@@ -5,6 +5,36 @@ namespace Text;
 
 public class WordUtils
 {
+    /// <summary>
+    /// Abbreviates the words nicely.
+    /// <para>
+    /// This method searches for the first space after the lower limit and abbreviates the string there. It will also
+    /// append any string passed as a parameter to the end of the string. The upper limit can be specified to forcibly
+    /// abbreviate a string.
+    /// </para>
+    /// </summary>
+    /// <param name="str">
+    /// The string to be abbreviated. If null is passed, null will be returned. If the empty string is passed, the empty
+    /// string will be returned.
+    /// </param>
+    /// <param name="lower">
+    /// The lower limit; negative value is treated as zero.
+    /// </param>
+    /// <param name="upper">
+    /// The upper limit; set to -1 if no limit is desired. The upper limit cannot be lower than the upper limit.
+    /// </param>
+    /// <param name="appendToEnd">
+    /// The string to be appended to the end of the abbreviated string. This is appended ONLY if the string was indeed
+    /// abbreviated. The append does not count towards the lower or upper limits.
+    /// </param>
+    /// <returns>The abbreviated string.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// If the upper limit is less than -1, or if the upper value is less than the lower value.
+    /// </exception>
+    /// <example>
+    /// WordUtils.Abbreviate("Now is the time for all good men", 0, 40, null));     = "Now"<br/>
+    /// WordUtils.Abbreviate("Now is the time for all good men", 0, 40, " ..."));   = "Now ..."
+    /// </example>
     public static string Abbreviate(string str, int lower, int upper, string appendToEnd)
     {
         if (upper < -1)

--- a/TextTests/WordUtilsTests.cs
+++ b/TextTests/WordUtilsTests.cs
@@ -1,0 +1,60 @@
+﻿using Text;
+
+namespace TextTests;
+
+[TestFixture]
+public class WordUtilsTests
+{
+    [TestCase("012 3456789", 0, 5, null, "012")]
+    [TestCase("01234 56789", 5, 10, null, "01234")]
+    [TestCase("01 23 45 67 89", 9, -1, null, "01 23 45 67")]
+    [TestCase("01 23 45 67 89", 9, 10, null, "01 23 45 6")]
+    [TestCase("0123456789", 15, 20, null, "0123456789")]
+    public void Abbreviate_ForLowerValue_ReturnsExpectedResults(
+        string str, int lower, int upper, string appendToEnd, string expected)
+    {
+        Assert.That(WordUtils.Abbreviate(str, lower, upper, appendToEnd), Is.EqualTo(expected));
+    }
+
+    [TestCase("012 3456789", 0, 5, null, "012")]
+    [TestCase("01234 56789", 5, 10, "-", "01234-")]
+    [TestCase("01 23 45 67 89", 9, -1, "abc", "01 23 45 67abc")]
+    [TestCase("01 23 45 67 89", 9, 10, null, "01 23 45 6")]
+    public void Abbreviate_LowerValueSetAndAppendedString_AbbreviatedStringReturned(
+        string str, int lower, int upper, string appendToEnd, string expected)
+    {
+        Assert.That(WordUtils.Abbreviate(str, lower, upper, appendToEnd), Is.EqualTo(expected));
+    }
+
+    [TestCase(null, 1, -1, null, null)]
+    [TestCase("", 1, -1, "", "")]
+    [TestCase("01234567890", 0, 0, "", "")]
+    [TestCase(" 01234567890", 0, -1, null, "")]
+    public void Abbreviate_ForNullAndEmptyString_ReturnsInputString(
+        string str, int lower, int upper, string appendToEnd, string expected)
+    {
+        Assert.That(WordUtils.Abbreviate(str, lower, upper, appendToEnd), Is.EqualTo(expected));
+    }
+
+    [TestCase("0123456789", 0, 5, "", "01234")]
+    [TestCase("012 3456789", 2, 5, "", "012")]
+    [TestCase("0123456789", 0, -1, "", "0123456789")]
+    public void Abbreviate_ForUpperLimit_ReturnsExpectedResults(
+        string str, int lower, int upper, string appendToEnd, string expected
+    )
+    {
+        Assert.That(WordUtils.Abbreviate(str, lower, upper, appendToEnd), Is.EqualTo(expected));
+    }
+    
+    [TestCase("0123456789", 0, 5, "-", "01234-")]
+    [TestCase("012 3456789", 2, 5, null, "012")]
+    [TestCase("0123456789", 0, -1, "", "0123456789")]
+    public void Abbreviate_ForUpperLimitAndAppendedString_ReturnsExpectedResults(
+        string str, int lower, int upper, string appendToEnd, string expected
+    )
+    {
+        Assert.That(WordUtils.Abbreviate(str, lower, upper, appendToEnd), Is.EqualTo(expected));
+    }
+    
+    
+}


### PR DESCRIPTION
This method abbreviates a given string by truncating it to a given length and appending a given string to the end. It takes in four parameters: the string to be abbreviated (`str`), the lower limit of how many characters the string should be shortened to (`lower`), the upper limit of how many characters the string should be shortened to (-1 meaning no upper limit) (`upper`), and the string to be appended to the end of the abbreviated string (`appendToEnd`). 

If the upper limit is less than -1 or the lower limit is greater than the upper limit (except when the upper limit is -1), an exception is thrown. 

If the input string is null or empty, it is returned as is. If the lower limit is greater than the length of the input string, the lower limit is set to the length of the input string. If the upper limit is -1 or greater than the length of the input string, the upper limit is set to the length of the input string. 

The method then finds the index of the first space character in the string after the lower limit and either truncates the string to the upper limit or to the index of the space character (whichever is smaller) and appends the `appendToEnd` string to the end before returning the result. 

Suppose no space character is found in the string after the lower limit. In that case, the string is truncated to the upper limit and the `appendToEnd` string is only appended if the string was actually truncated (the upper limit is not equal to the length of the input string).