### PR TITLE
:sparkles: Text: Add WordUtils.ContainsAllWords method

### DIFF
--- a/Text/WordUtils.cs
+++ b/Text/WordUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Text;
 
@@ -165,6 +166,29 @@ public static class WordUtils
 
         str = str.ToLower(CultureInfo.InvariantCulture);
         return Capitalize(str, delimiters);
+    }
+
+    /// <summary>
+    /// Checks if the string contains all the words in the given array.
+    /// </summary>
+    /// <param name="str">The string to check, may be null.</param>
+    /// <param name="words">The array of words to search for, may be null.</param>
+    /// <returns>True if all search words are found, false otherwise.</returns>
+    /// <remarks>
+    /// A null string will return false. A null, zero length search array or if one element of the array is null, will
+    /// return null.
+    /// </remarks>
+    /// <example>
+    /// WordUtils.ContainsAllWords(null, *) = false <br/>
+    /// WordUtils.ContainsAllWords("abcd", "ab", "cd") = false <br/>
+    /// WordUtils.ContainsAllWords("abc, def", "def", "abc") = true
+    /// </example>
+    public static bool ContainsAllWords(string str, params string[]? words)
+    {
+        if (string.IsNullOrEmpty(str) || words == null || !words.Any())
+            return false;
+
+        return words.All(word => !string.IsNullOrEmpty(word) && Regex.IsMatch(str, $@"\b{word}\b"));
     }
     
     private static HashSet<int> GenerateDelimiterSet(IReadOnlyList<char>? delimiters)

--- a/TextTests/WordUtilsTests.cs
+++ b/TextTests/WordUtilsTests.cs
@@ -95,4 +95,32 @@ public class WordUtilsTests
         char[] delimiters = { '-', '+', ' ', '@' };
         Assert.That(WordUtils.CapitalizeFully(str, delimiters), Is.EqualTo(expected));
     }
+
+    [TestCase(null, null, false)]
+    [TestCase(null, new string[] { "" }, false)]
+    [TestCase(null, new string[] { "ab" }, false)]
+    public void ContainsAllWords_WithNullString_ReturnsFalse(string str, string[] terms, bool expected)
+    {
+        Assert.That(WordUtils.ContainsAllWords(str, terms), Is.EqualTo(expected));
+    }
+
+    [TestCase("", null, false)]
+    [TestCase("", new string[] { "" }, false)]
+    [TestCase("", new string[] { "ab" }, false)]
+    public void ContainsAllWords_WithEmptyString_ReturnsFalse(string str, string[] terms, bool expected)
+    {
+        Assert.That(WordUtils.ContainsAllWords(str, terms), Is.EqualTo(expected));
+    }
+
+    [TestCase("foo", null, false)]
+    [TestCase("bar", new string[] { "" }, false)]
+    [TestCase("zzabyyxdxx", new string[] { "ab" }, false)]
+    [TestCase("lorem ipsum dolor sit amet", new string[] { "ipsum", "lorem", "dolor" }, true)]
+    [TestCase("lorem ipsum dolor sit amet", new string[] { "ipsum", null, "lorem", "dolor" }, false)]
+    [TestCase("lorem null ipsum dolor sit amet", new string[] { "ipsum", null, "lorem", "dolor" }, false)]
+    public void ContainsAllWords_WithValidStringAndTerms_ReturnsExpectedResults(string str, string[] terms,
+        bool expected)
+    {
+        Assert.That(WordUtils.ContainsAllWords(str, terms), Is.EqualTo(expected));
+    }
 }


### PR DESCRIPTION
The ContainsAllWords method can be used to check whether a string contains all of the specified words. Here are a few examples of use cases:
1. Searching for a specific phrase in a document: The method can be used to check whether a document contains a specific phrase by searching for all of the words in the phrase.
2. Validating user input: The method can be used to validate user input to ensure that it contains certain keywords. For example, a form might require users to enter their name and email address, and the method could be used to ensure that the user's input contains both of these keywords.
3. Filtering data: The method can be used to filter a collection of strings based on whether they contain certain keywords. For example, a list of product names could be filtered to only include products that contain the keywords "red" and "shirt".

The `ContainsAllWords` method checks if the provided string `str` contains all the words in the words array. It returns `false` if either `str` is `null` or empty, or `words` is `null` or empty. Otherwise, it checks if all the words in the `words` array are contained in `str` using a regular expression pattern that checks for whole-word matches. If all the words are found in `str`, it returns `true`, otherwise it returns `false`.