### PR TITLE
:sparkles: Text: Add WordUtils.Uncapitalize method

### DIFF
--- a/Text/WordUtils.cs
+++ b/Text/WordUtils.cs
@@ -222,6 +222,62 @@ public static class WordUtils
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Uncapitalizes all the whitespace separated words in a string. Only the first character of each word is changed.
+    /// </summary>
+    /// <param name="str">The string to uncapitalize, may be null.</param>
+    /// <returns>The uncapitalized string, or null for null string input.</returns>
+    /// <example>
+    /// WordUtils.Uncapitalize(null) = null <br/>
+    /// WordUtils.Uncapitalize("") = "" <br/>
+    /// WordUtils.Uncapitalize("I Am FINE") = "i am fINE"
+    /// </example>
+    public static string Uncapitalize(string str)
+    {
+        return Uncapitalize(str, null);
+    }
+    
+    /// <summary>
+    /// Uncapitalizes all the whitespace separated words in a string. Only the first character of each word is changed.
+    /// </summary>
+    /// <param name="str">The string to uncapitalize, may be null.</param>
+    /// <param name="delimiters">A set of characters to determine uncapitalization. Null means whitespace.</param>
+    /// <returns>The uncapitalized string, or null for null string input.</returns>
+    /// <remarks>
+    /// The delimiters represent a set of characters understood to separate words. The first string character and the
+    ///first non-delimiter character after a delimiter will be uncapitalized.
+    /// </remarks>
+    public static string Uncapitalize(string str, params char[]? delimiters)
+    {
+        if (string.IsNullOrEmpty(str))
+            return str;
+
+        var delimiterSet = GenerateDelimiterSet(delimiters);
+        var sb = new StringBuilder(str.Length);
+
+        bool uncapitalizeNext = true;
+        foreach (var c in str)
+        {
+            if (delimiterSet.Contains(c))
+            {
+                uncapitalizeNext = true;
+                sb.Append(c);
+            }
+            else if (uncapitalizeNext)
+            {
+                sb.Append(char.ToLower(c));
+                uncapitalizeNext = false;
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+
     private static HashSet<int> GenerateDelimiterSet(IReadOnlyList<char>? delimiters)
     {
         var delimiterHashSet = new HashSet<int>();

--- a/TextTests/WordUtilsTests.cs
+++ b/TextTests/WordUtilsTests.cs
@@ -131,7 +131,7 @@ public class WordUtilsTests
     {
         Assert.That(WordUtils.SwapCase(str), Is.EqualTo(expected));
     }
-    
+
     [TestCase("I", "i")]
     [TestCase("i", "I")]
     [TestCase("i am here 123", "I AM HERE 123")]
@@ -142,4 +142,46 @@ public class WordUtilsTests
     {
         Assert.That(WordUtils.SwapCase(str), Is.EqualTo(expected));
     }
+
+    [TestCase(null, null)]
+    [TestCase("", "")]
+    [TestCase(" ", " ")]
+    public void Uncapitalize_WithoutDelimiterListAndEmptyInput_ReturnsExpectedResults(string str, string expected)
+    {
+        Assert.That(WordUtils.Uncapitalize(str), Is.EqualTo(expected));
+    }
+
+    [TestCase("I", "i")]
+    [TestCase("i", "i")]
+    [TestCase("i am here 123", "i am here 123")]
+    [TestCase("I Am Here 123", "i am here 123")]
+    [TestCase("i am HERE 123", "i am hERE 123")]
+    [TestCase("I AM HERE 123", "i aM hERE 123")]
+    public void Uncapitalize_WithoutDelimiterListAndRandomCasedStringInput_ReturnsExpectedResults(string str,
+        string expected)
+    {
+        Assert.That(WordUtils.Uncapitalize(str), Is.EqualTo(expected));
+    }
+
+    [TestCase(null, null, null)]
+    [TestCase("", new char[]{}, "")]
+    [TestCase(" ", new char[]{}, " ")]
+    public void Uncapitalize_WithEmptyDelimiterListAndEmptyInput_ReturnsExpectedResults(string str, char[]? delimiters,
+        string expected)
+    {
+        Assert.That(WordUtils.Uncapitalize(str, delimiters), Is.EqualTo(expected));
+    }
+    
+    [TestCase("I", new char[]{'-', '+', ' ', '@'}, "i")]
+    [TestCase("i", new char[]{'-', '+', ' ', '@'}, "i")]
+    [TestCase("i am-here+123", new char[]{'-', '+', ' ', '@'}, "i am-here+123")]
+    [TestCase("I+Am Here-123", new char[]{'-', '+', ' ', '@'}, "i+am here-123")]
+    [TestCase("i-am+HERE 123", new char[]{'-', '+', ' ', '@'}, "i-am+hERE 123")]
+    [TestCase("I AM-HERE+123", new char[]{'-', '+', ' ', '@'}, "i aM-hERE+123")]
+    public void Uncapitalize_WithDelimiterListAndInput_ReturnsExpectedResults(string str, char[]? delimiters,
+        string expected)
+    {
+        Assert.That(WordUtils.Uncapitalize(str, delimiters), Is.EqualTo(expected));
+    }
+
 }


### PR DESCRIPTION
`Uncapitalize` takes a string and an array of characters as input and returns the modified string where the first character of each word (sequence of characters separated by the specified delimiters) is converted to lowercase unless it is already in lowercase. If no delimiters are provided, the default delimiter is the space character.

Some possible use cases for this method are:

Normalizing the capitalization of a string for further processing or display. For example, you might want to display a title in sentence case (first letter of the first word in uppercase, the rest in lowercase) instead of the original title case (first letter of every word in uppercase).
Modifying the capitalization of a string to match a specific style guide or convention. For example, you might want to convert a string written in all uppercase to title case or sentence case.
Ensuring that the capitalization of a string matches the expected input format for a particular application or service. For example, you might want to make sure that the first letter of every word in a string is lowercase before sending it as a query to a search engine.